### PR TITLE
Fixes incorrect link syntax in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ less breadth with great depth). All of the articles here will be written for
 PHP 7 (powered by the Zend Engine version 3 (ZE3)) and above.
 
 These articles assume that the reader is able to build PHP from source. If this
-is not the case, then please see the [Building PHP]
-(http://www.phpinternalsbook.com/build_system/building_php.html) chapter of
+is not the case, then please see the [Building PHP](http://www.phpinternalsbook.com/build_system/building_php.html) chapter of
 the [PHP Internals Book](http://www.phpinternalsbook.com/) first.
 
 
@@ -18,8 +17,7 @@ the [PHP Internals Book](http://www.phpinternalsbook.com/) first.
  - Range Operator:
    - [Part 1] [Implementing a Range Operator in PHP](https://github.com/tpunt/php-internals-articles/blob/master/articles/range-operator.md)
    - [Part 2] [A Reimplementation of the Range Operator](https://github.com/tpunt/php-internals-articles/blob/master/articles/range-operator-2.md)
- - [Implementing a Digit Separator in PHP]
- (https://github.com/tpunt/php-internals-articles/blob/master/articles/digit-separator.md)
+ - [Implementing a Digit Separator in PHP](https://github.com/tpunt/php-internals-articles/blob/master/articles/digit-separator.md)
 
 
 Feel free to open up issues to request/suggest topics that you would like to see covered!


### PR DESCRIPTION
There were two cases where the square bracket `]` id not touch the parentheses `(`.

This MR fixes that.